### PR TITLE
Changed default database dotenv configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-DB_PASSWORD=changeme
+DB_PASSWORD=nginx
 WIKI_UPGRADE_KEY=changeme
 WIKI_SECRET_KEY=changeme


### PR DESCRIPTION
Changes the database password to the same as defined in the
docker-compose file. This allows you to start up the solution without
making any modifications to the dotenv file when you clone the solution.