### PR TITLE
api: split out env usage into configuration

### DIFF
--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -1,0 +1,20 @@
+const env = process.env.NODE_ENV || 'development'
+
+const logLevels: Record<string, string> = {
+	test: 'error',
+	development: 'debug',
+	production: 'info'
+}
+
+const production = env === 'production'
+
+export default {
+	env,
+	production,
+	database: {
+		connection: `mariadb://expidus:${process.env.DB_PASSWORD}@db/expidus`
+	},
+	winston: {
+		level: logLevels[env]
+	}
+}

--- a/packages/api/src/database/index.ts
+++ b/packages/api/src/database/index.ts
@@ -4,6 +4,7 @@ import Client from './models/client'
 import Publisher from './models/publisher'
 import Staff from './models/staff'
 import User from './models/user'
+import config from '../config'
 
 export const models = {
 	AccessToken,
@@ -13,7 +14,7 @@ export const models = {
 	User
 }
 
-export const sequelize = new Sequelize(`mariadb://expidus:${process.env.DB_PASSWORD}@db/expidus`)
+export const sequelize = new Sequelize(config.database.connection)
 
 Object
 	.values(models)

--- a/packages/api/src/providers/winston.ts
+++ b/packages/api/src/providers/winston.ts
@@ -1,7 +1,8 @@
 import winston from 'winston'
+import config from '../config'
 
 const logger = winston.createLogger({
-	level: process.env.NODE_ENV == 'development' ? 'debug' : 'info',
+	level: config.winston.level,
 	format: winston.format.combine(
 		winston.format.colorize(),
 		winston.format.splat(),


### PR DESCRIPTION
This is better in terms of portability and management of all
configurations, espcially as the application expands.

Also makes it easy to customize based on what environment the
API is running in.